### PR TITLE
fix: stop non-3.12 CI test failures caused by uv run env drift

### DIFF
--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -2,6 +2,8 @@ import shutil
 import time
 from pathlib import Path
 
+import polars as pl
+
 from histoslice import Slide
 from histoslice.functional import has_jpeg_support
 
@@ -54,6 +56,18 @@ def create_tiles_with_metrics() -> Path:
         save_thumbnails=False,
     )
     return output_dir
+
+
+def make_bad_slide_dir(name: str) -> Path:
+    """A slide directory with metadata.parquet but no metric columns, so
+    `OutlierDetector` raises when `clean` processes it. Returns the directory.
+    """
+    bad_dir = TMP_DIRECTORY / name
+    bad_dir.mkdir(parents=True)
+    pl.DataFrame(
+        {"x": [0], "y": [0], "w": [1], "h": [1], "path": ["x.jpeg"]}
+    ).write_parquet(bad_dir / "metadata.parquet")
+    return bad_dir
 
 
 # Optional dependency flags and asset availability

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,9 +1,12 @@
+import polars as pl
+
 from ._utils import (
     IMAGE_EXT,
     SLIDE_PATH_JPEG,
     TMP_DIRECTORY,
     clean_temporary_directory,
     create_tiles_with_metrics,
+    make_bad_slide_dir,
 )
 
 
@@ -21,6 +24,7 @@ def test_run(script_runner) -> None:  # noqa
         [
             "uv",
             "run",
+            "--no-sync",
             "histoslice",
             "slice",
             "-i",
@@ -45,6 +49,29 @@ def test_run(script_runner) -> None:  # noqa
     clean_temporary_directory()
 
 
+def test_slice_command_parallel(script_runner) -> None:  # noqa
+    """`-j 2` dispatches through `ProcessPoolExecutor` in a real subprocess."""
+    clean_temporary_directory()
+    ret = script_runner.run(
+        [
+            "uv",
+            "run",
+            "--no-sync",
+            "histoslice",
+            "slice",
+            "-i",
+            str(SLIDE_PATH_JPEG),
+            "-o",
+            str(TMP_DIRECTORY),
+            "-j",
+            "2",
+        ]
+    )
+    assert ret.success
+    assert (TMP_DIRECTORY / "slide" / "metadata.parquet").exists()
+    clean_temporary_directory()
+
+
 def test_skip_processed(script_runner) -> None:  # noqa
     clean_temporary_directory()
     create_metadata(unfinished=False)
@@ -52,6 +79,7 @@ def test_skip_processed(script_runner) -> None:  # noqa
         [
             "uv",
             "run",
+            "--no-sync",
             "histoslice",
             "slice",
             "-i",
@@ -75,6 +103,7 @@ def test_overwrite(script_runner) -> None:  # noqa
         [
             "uv",
             "run",
+            "--no-sync",
             "histoslice",
             "slice",
             "-i",
@@ -107,6 +136,7 @@ def test_unfinished(script_runner) -> None:  # noqa
         [
             "uv",
             "run",
+            "--no-sync",
             "histoslice",
             "slice",
             "-i",
@@ -150,6 +180,7 @@ def test_run_with_error_multi_process(script_runner, monkeypatch) -> None:  # no
         [
             "uv",
             "run",
+            "--no-sync",
             "histoslice",
             "slice",
             "-i",
@@ -184,6 +215,7 @@ def test_run_with_error_single_process(script_runner, monkeypatch) -> None:  # n
         [
             "uv",
             "run",
+            "--no-sync",
             "histoslice",
             "slice",
             "-i",
@@ -202,8 +234,6 @@ def test_run_with_error_single_process(script_runner, monkeypatch) -> None:  # n
 
 def test_clean_command_move(script_runner) -> None:  # noqa
     """Test clean command creates metadata_clean.parquet with is_outlier and method columns."""
-    import polars as pl
-
     clean_temporary_directory()
     create_tiles_with_metrics()
 
@@ -217,6 +247,7 @@ def test_clean_command_move(script_runner) -> None:  # noqa
         [
             "uv",
             "run",
+            "--no-sync",
             "histoslice",
             "clean",
             "-i",
@@ -248,6 +279,36 @@ def test_clean_command_move(script_runner) -> None:  # noqa
     clean_temporary_directory()
 
 
+def test_clean_command_parallel(script_runner) -> None:  # noqa
+    """`-j 2` dispatches through `ProcessPoolExecutor` in a real subprocess."""
+    clean_temporary_directory()
+    create_tiles_with_metrics()
+
+    ret = script_runner.run(
+        [
+            "uv",
+            "run",
+            "--no-sync",
+            "histoslice",
+            "clean",
+            "-i",
+            str(TMP_DIRECTORY / "slide"),
+            "-k",
+            "4",
+            "-j",
+            "2",
+        ]
+    )
+
+    assert ret.success
+    clean_parquet = TMP_DIRECTORY / "slide" / "metadata_clean.parquet"
+    assert clean_parquet.exists()
+    df = pl.read_parquet(clean_parquet)
+    assert "is_outlier" in df.columns
+
+    clean_temporary_directory()
+
+
 def test_clean_command_delete(script_runner) -> None:  # noqa
     """Test that the --delete flag is no longer accepted (removed from CLI)."""
     clean_temporary_directory()
@@ -258,6 +319,7 @@ def test_clean_command_delete(script_runner) -> None:  # noqa
         [
             "uv",
             "run",
+            "--no-sync",
             "histoslice",
             "clean",
             "-i",
@@ -285,6 +347,7 @@ def test_clean_command_no_metadata(script_runner) -> None:  # noqa
         [
             "uv",
             "run",
+            "--no-sync",
             "histoslice",
             "clean",
             "-i",
@@ -307,6 +370,7 @@ def test_clean_command_invalid_mode(script_runner) -> None:  # noqa
         [
             "uv",
             "run",
+            "--no-sync",
             "histoslice",
             "clean",
             "-i",
@@ -339,6 +403,7 @@ def test_clean_command_unsupported_format(script_runner) -> None:  # noqa
         [
             "uv",
             "run",
+            "--no-sync",
             "histoslice",
             "clean",
             "-i",
@@ -369,6 +434,7 @@ def test_clean_command_missing_tile_files(script_runner) -> None:  # noqa
         [
             "uv",
             "run",
+            "--no-sync",
             "histoslice",
             "clean",
             "-i",
@@ -401,6 +467,7 @@ def test_clean_command_exception_handling(script_runner, monkeypatch) -> None:  
         [
             "uv",
             "run",
+            "--no-sync",
             "histoslice",
             "clean",
             "-i",
@@ -420,6 +487,32 @@ def test_clean_command_exception_handling(script_runner, monkeypatch) -> None:  
     clean_temporary_directory()
 
 
+def test_clean_command_reports_per_slide_exception_parallel(script_runner) -> None:  # noqa
+    """`-j 2` reports per-slide exceptions the same way as sequential mode."""
+    clean_temporary_directory()
+    create_tiles_with_metrics()
+    make_bad_slide_dir("bad")
+
+    ret = script_runner.run(
+        [
+            "uv",
+            "run",
+            "--no-sync",
+            "histoslice",
+            "clean",
+            "-i",
+            str(TMP_DIRECTORY / "*"),
+            "-j",
+            "2",
+        ]
+    )
+
+    assert ret.success
+    assert "Could not process" in ret.stdout
+
+    clean_temporary_directory()
+
+
 def test_clean_command_no_outliers(script_runner) -> None:  # noqa
     """Test clean command when no outliers are detected."""
     clean_temporary_directory()
@@ -430,6 +523,7 @@ def test_clean_command_no_outliers(script_runner) -> None:  # noqa
         [
             "uv",
             "run",
+            "--no-sync",
             "histoslice",
             "clean",
             "-i",

--- a/tests/cli_unit_test.py
+++ b/tests/cli_unit_test.py
@@ -5,6 +5,12 @@ real subprocess (`uv run histoslice ...`) - good for verifying the installed
 entry point, but coverage tooling can't see inside that separate process.
 These tests invoke the same `app` in-process to cover argument parsing,
 orchestration, and error handling directly.
+
+Multi-process (`-j` > 0) dispatch is intentionally NOT exercised here: it
+spawns real worker processes via `ProcessPoolExecutor`, which need to
+reconstruct pytest's own `__main__` entry point when run in-process. That is
+unreliable across Python versions/environments, so parallel dispatch is
+covered instead via real subprocess invocations in `tests/cli_test.py`.
 """
 
 import sys
@@ -28,6 +34,7 @@ from ._utils import (
     TMP_DIRECTORY,
     clean_temporary_directory,
     create_tiles_with_metrics,
+    make_bad_slide_dir,
 )
 
 runner = CliRunner()
@@ -38,17 +45,6 @@ def test_slice_command_sequential() -> None:
     result = runner.invoke(
         app,
         ["slice", "-i", str(SLIDE_PATH_JPEG), "-o", str(TMP_DIRECTORY), "-j", "0"],
-    )
-    assert result.exit_code == 0
-    assert (TMP_DIRECTORY / "slide" / "metadata.parquet").exists()
-    clean_temporary_directory()
-
-
-def test_slice_command_parallel() -> None:
-    clean_temporary_directory()
-    result = runner.invoke(
-        app,
-        ["slice", "-i", str(SLIDE_PATH_JPEG), "-o", str(TMP_DIRECTORY), "-j", "2"],
     )
     assert result.exit_code == 0
     assert (TMP_DIRECTORY / "slide" / "metadata.parquet").exists()
@@ -207,44 +203,21 @@ def test_clean_command_no_slide_dirs() -> None:
     assert result.exit_code == 1
 
 
-def test_clean_command_sequential_and_parallel() -> None:
+def test_clean_command_sequential() -> None:
     clean_temporary_directory()
     slide_dir = create_tiles_with_metrics()
 
     result = runner.invoke(app, ["clean", "-i", str(slide_dir), "-k", "2", "-j", "0"])
     assert result.exit_code == 0
     assert (slide_dir / "metadata_clean.parquet").exists()
-
-    result = runner.invoke(app, ["clean", "-i", str(slide_dir), "-k", "2", "-j", "2"])
-    assert result.exit_code == 0
     clean_temporary_directory()
-
-
-def _make_bad_slide_dir(name: str) -> None:
-    """A slide directory with metadata.parquet but no metric columns, so
-    `OutlierDetector` raises when `clean` processes it."""
-    bad_dir = TMP_DIRECTORY / name
-    bad_dir.mkdir(parents=True)
-    pl.DataFrame(
-        {"x": [0], "y": [0], "w": [1], "h": [1], "path": ["x.jpeg"]}
-    ).write_parquet(bad_dir / "metadata.parquet")
 
 
 def test_clean_command_reports_per_slide_exception_sequential() -> None:
     clean_temporary_directory()
     create_tiles_with_metrics()
-    _make_bad_slide_dir("bad")
+    make_bad_slide_dir("bad")
     result = runner.invoke(app, ["clean", "-i", str(TMP_DIRECTORY / "*"), "-j", "0"])
-    assert result.exit_code == 0
-    assert "Could not process" in result.output
-    clean_temporary_directory()
-
-
-def test_clean_command_reports_per_slide_exception_parallel() -> None:
-    clean_temporary_directory()
-    create_tiles_with_metrics()
-    _make_bad_slide_dir("bad")
-    result = runner.invoke(app, ["clean", "-i", str(TMP_DIRECTORY / "*"), "-j", "2"])
     assert result.exit_code == 0
     assert "Could not process" in result.output
     clean_temporary_directory()


### PR DESCRIPTION
## Summary

- Tests were failing in CI on every Python version except 3.12. The cause was not actually the parallel-execution *product* code — it was environment drift caused by the test suite's own subprocess calls.
- `.python-version` pins Python 3.12, but the ~17 CLI subprocess tests invoke bare `uv run histoslice ...` without a `--python` flag. On non-3.12 CI jobs, each `uv run` call tried to re-resolve/sync an environment matching the `.python-version` pin against the already-active `.venv` (built for the matrix's Python version), mutating shared site-packages mid test run while the parent pytest process was still reading from it. That produced `BrokenProcessPool` (wrong interpreter spawned for multiprocessing workers) and `ImportError: cannot import name 'rich_utils' from 'typer'` (typer's package files swapped out mid-import). On the 3.12 job the pin already matched, so nothing needed re-syncing — hence only 3.12 passed.
- Fixed by adding `--no-sync` to every `uv run histoslice ...` subprocess invocation in `tests/cli_test.py`, so `uv` reuses the already-synced environment instead of re-resolving it.
- Also moved the two `-j 2` (parallel) CLI assertions that ran **in-process** via Typer's `CliRunner` into real subprocess tests in `tests/cli_test.py`. Spawning `ProcessPoolExecutor` workers from inside pytest's own process requires reconstructing pytest's `__main__` entry point, which is inherently unreliable across environments and isn't how the feature is actually exercised in production.

## Test plan

- [x] `uv run --python 3.10 pytest` — passes (only a pre-existing root-user chmod artifact fails locally; not a real CI issue since GitHub Actions runners aren't root)
- [x] `uv run --python 3.11 pytest` — passes (same artifact only)
- [x] `uv run --python 3.12 pytest` — passes (same artifact only, confirms no regression)
- [x] `uv run --python 3.13 pytest` — passes (same artifact only)
- [x] `ruff check` / `ruff format --check`


---
_Generated by [Claude Code](https://claude.ai/code/session_01S4yLpmSVwtHEjcQ4U1vNTH)_